### PR TITLE
Add code to save results as JPG images and create HTML file to visualize results

### DIFF
--- a/CaeMainOM_Exp1.py
+++ b/CaeMainOM_Exp1.py
@@ -34,8 +34,6 @@ Note2: The early stopping is not implemented yet.
 import sys
 import os
 import time
-import glob
-import PIL.Image as Image
 import numpy as np
 
 import theano
@@ -47,107 +45,9 @@ import lasagne
 #import Cae_BigDense
 import Cae
 
-
-#################
-
-def im2ar(x):
-    y = [[[0]*len(x)]*len(x)]*3
-    y[0] = x[:,:,0]
-    y[1] = x[:,:,1]
-    y[2] = x[:,:,2]
-    return y
-
-def ar2im(x):
-    y = [[[0]*3]*len(x)]*len(x)
-    y[:,:,0] = x[0,:,:] 
-    y[:,:,1] = x[1,:,:]
-    y[:,:,2] = x[2,:,:]
-    return y
+from common import im2ar, ar2im, np_ar2im, load_dataset_mscoco
+from common import save_jpg_results, create_html_results_page
     
-##################
-
-def load_dataset_mscoco():
-    #Path
-    
-    mscoco="/home2/ift6ed38/PythonCode/inpainting"
-    #mscoco="/home2/ift6ed38/PythonCode/inpainting"
-    split="train2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    print("cantidad de imagenes = "+str(len(imgs)))
-    
-    MAXIMAS_train = 5000
-    MAXIMAS_val   = 1000
-    TESTSETsize   =  100
-    
-    X_train = []
-    y_train = []
-
-    
-    
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_train: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for training was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            temp = np.copy(img_array)
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_train.append(im2ar(input))
-        y_train.append(im2ar(target))
-    
-    split="val2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    
-    X_val = []
-    y_val = []
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_val: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for validation was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_val.append(im2ar(input))
-        y_val.append(im2ar(target))
-    
-    # We reserve the last TESTSETsize training examples for testing. (was 10000)
-    print("From the validation set, the last  "+str(TESTSETsize)+" images are chosen for testing") 
-    X_val, X_test = X_val[:-TESTSETsize], X_val[-TESTSETsize:]
-    y_val, y_test = y_val[:-TESTSETsize], y_val[-TESTSETsize:]
-    
-    return (np.array(X_train),np.array(y_train),np.array(X_val),np.array(y_val),np.array(X_test),np.array(y_test))
-    
-
 ###################
 
 # Batch iterator
@@ -193,10 +93,11 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    num_epochs = 20 #was 100
+    #num_epochs = 20 #was 100
+    num_epochs = 1
     learning_rate = 0.001
     momentum = 0.975
-    batchsize = 10 #Was 200
+    batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.
     #If this coefficient is set to "0", the loss is just the L2 loss.
@@ -204,7 +105,7 @@ def main():
     
     # Load the dataset
     print("Loading data...")
-    X_train, y_train, X_val, y_val, X_test, y_test = load_dataset_mscoco()
+    X_train, y_train, X_val, y_val, X_test, y_test, X_original_test = load_dataset_mscoco()
     #print("length of y_train = " + str(y_train))
     #print("length of y_val = "+ str(y_val))
     #print("length of y_test = "+str(y_test))
@@ -233,7 +134,8 @@ def main():
     # Update expressions 
     # Stochastic Gradient Descent (SGD) with Nesterov momentum
     params = lasagne.layers.get_all_params(network, trainable=True)
-    updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    #updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    updates = lasagne.updates.adam(loss, params, learning_rate)
 
     # Test Loss expression
     # 'Deterministic = True' disables droupout
@@ -246,6 +148,10 @@ def main():
 
     # Test Function
     val_fn = theano.function([inputVar, target_var], test_loss)
+
+    # Predict function
+    predict = theano.function([inputVar], test_prediction)
+    
     # Training Loop
     print("Starting training...")
     # We iterate over epochs
@@ -273,24 +179,38 @@ def main():
         print("Epoch {} of {} took {:.3f}s".format(
             epoch + 1, num_epochs, time.time() - start_time))
         #print("  COMMENTARY: train_batches = "+str(train_batches))
-        print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
-        print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
+        if train_batches == 0:
+            print("train_batches is 0, can't compute training loss")
+        else:
+            print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
+        if val_batches == 0:
+            print("val_batches is 0, can't compute validation loss")
+        else:
+            print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
 
     # Print the test error
     test_err = 0
     test_batches = 0
+    preds = np.zeros((X_test.shape[0], 3, 32, 32))
     for batch in iterate_minibatches(X_test, y_test, batchsize, shuffle=False):
         inputs, targets = batch
+        preds[test_batches*batchsize:(test_batches+1)*batchsize] = predict(inputs)
         err = val_fn(inputs, targets)
         test_err += err
         test_batches += 1
     print("Final results:")
-    print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
-
+    if test_batches == 0:
+        print("test_batches is 0, can't compute test loss.")
+    else:
+        print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
 
     # Save model
     np.savez('caeOM-exp1.npz', *lasagne.layers.get_all_param_values(network))
-        
+
+    # Save predictions and create HTML page to visualize them
+    save_jpg_results("assets_exp1/", preds, X_test, y_test, X_original_test)
+    create_html_results_page("results_exp1.html", "assets_exp1/", preds.shape[0])
+
 ###########################
 
 if __name__ == '__main__':

--- a/CaeMainOM_Exp1.py
+++ b/CaeMainOM_Exp1.py
@@ -93,10 +93,8 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    #num_epochs = 20 #was 100
-    num_epochs = 1
+    num_epochs = 12 #was 100
     learning_rate = 0.001
-    momentum = 0.975
     batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.

--- a/CaeMainOM_Exp2.py
+++ b/CaeMainOM_Exp2.py
@@ -95,9 +95,8 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    num_epochs = 1 #was 100
+    num_epochs = 15 #was 100
     learning_rate = 0.001
-    momentum = 0.975
     batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.

--- a/CaeMainOM_Exp2.py
+++ b/CaeMainOM_Exp2.py
@@ -34,8 +34,6 @@ Note2: The early stopping is not implemented yet.
 import sys
 import os
 import time
-import glob
-import PIL.Image as Image
 import numpy as np
 
 import theano
@@ -46,105 +44,11 @@ import lasagne
 #import Cae
 import Cae_BigDense
 
+from common import im2ar, ar2im, np_ar2im, load_dataset_mscoco
+from common import save_jpg_results, create_html_results_page
+
 
 #################
-
-def im2ar(x):
-    y = [[[0]*len(x)]*len(x)]*3
-    y[0] = x[:,:,0]
-    y[1] = x[:,:,1]
-    y[2] = x[:,:,2]
-    return y
-
-def ar2im(x):
-    y = [[[0]*3]*len(x)]*len(x)
-    y[:,:,0] = x[0,:,:] 
-    y[:,:,1] = x[1,:,:]
-    y[:,:,2] = x[2,:,:]
-    return y
-    
-##################
-
-def load_dataset_mscoco():
-    #Path
-    
-    mscoco="/home2/ift6ed38/PythonCode/inpainting"
-    split="train2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    print("cantidad de imagenes = "+str(len(imgs)))
-    
-    MAXIMAS_train = 5000
-    MAXIMAS_val   = 1000
-    TESTSETsize   =  100
-    
-    X_train = []
-    y_train = []
-
-    
-    
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_train: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for training was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            temp = np.copy(img_array)
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_train.append(im2ar(input))
-        y_train.append(im2ar(target))
-    
-    split="val2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    
-    X_val = []
-    y_val = []
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_val: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for validation was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_val.append(im2ar(input))
-        y_val.append(im2ar(target))
-    
-    # We reserve the last TESTSETsize training examples for testing. (was 10000)
-    print("From the validation set, the last  "+str(TESTSETsize)+" images are chosen for testing") 
-    X_val, X_test = X_val[:-TESTSETsize], X_val[-TESTSETsize:]
-    y_val, y_test = y_val[:-TESTSETsize], y_val[-TESTSETsize:]
-    
-    return (np.array(X_train),np.array(y_train),np.array(X_val),np.array(y_val),np.array(X_test),np.array(y_test))
-    
 
 ###################
 
@@ -191,10 +95,10 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    num_epochs = 20 #was 100
+    num_epochs = 1 #was 100
     learning_rate = 0.001
     momentum = 0.975
-    batchsize = 10 #Was 200
+    batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.
     #If this coefficient is set to "0", the loss is just the L2 loss.
@@ -202,7 +106,7 @@ def main():
     
     # Load the dataset
     print("Loading data...")
-    X_train, y_train, X_val, y_val, X_test, y_test = load_dataset_mscoco()
+    X_train, y_train, X_val, y_val, X_test, y_test, X_original_test = load_dataset_mscoco()
     #print("length of y_train = " + str(y_train))
     #print("length of y_val = "+ str(y_val))
     #print("length of y_test = "+str(y_test))
@@ -231,7 +135,8 @@ def main():
     # Update expressions 
     # Stochastic Gradient Descent (SGD) with Nesterov momentum
     params = lasagne.layers.get_all_params(network, trainable=True)
-    updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    #updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    updates = lasagne.updates.adam(loss, params, learning_rate)
 
     # Test Loss expression
     # 'Deterministic = True' disables droupout
@@ -244,6 +149,10 @@ def main():
 
     # Test Function
     val_fn = theano.function([inputVar, target_var], test_loss)
+
+    # Predict function
+    predict = theano.function([inputVar], test_prediction)
+
     # Training Loop
     print("Starting training...")
     # We iterate over epochs
@@ -271,24 +180,39 @@ def main():
         print("Epoch {} of {} took {:.3f}s".format(
             epoch + 1, num_epochs, time.time() - start_time))
         #print("  COMMENTARY: train_batches = "+str(train_batches))
-        print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
-        print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
+        if train_batches == 0:
+            print("train_batches is 0, can't compute training loss")
+        else:
+            print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
+        if val_batches == 0:
+            print("val_batches is 0, can't compute validation loss")
+        else:
+            print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
 
     # Print the test error
     test_err = 0
     test_batches = 0
+    preds = np.zeros((X_test.shape[0], 3, 32, 32))
     for batch in iterate_minibatches(X_test, y_test, batchsize, shuffle=False):
         inputs, targets = batch
+        preds[test_batches*batchsize:(test_batches+1)*batchsize] = predict(inputs)
         err = val_fn(inputs, targets)
         test_err += err
         test_batches += 1
     print("Final results:")
-    print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
+    if test_batches == 0:
+        print("test_batches is 0, can't compute test loss.")
+    else:
+        print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
 
 
     # Save model
     np.savez('caeOM-exp2.npz', *lasagne.layers.get_all_param_values(network))
-        
+
+    # Save predictions and create HTML page to visualize them
+    save_jpg_results("assets_exp2/", preds, X_test, y_test, X_original_test)
+    create_html_results_page("results_exp2.html", "assets_exp2/", preds.shape[0])
+    
 ###########################
 
 if __name__ == '__main__':

--- a/CaeMainOM_Exp3.py
+++ b/CaeMainOM_Exp3.py
@@ -91,9 +91,8 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    num_epochs = 1 #was 100
+    num_epochs = 15 #was 100
     learning_rate = 0.001
-    momentum = 0.975
     batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.

--- a/CaeMainOM_Exp3.py
+++ b/CaeMainOM_Exp3.py
@@ -33,8 +33,6 @@ Note2: The early stopping is not implemented yet.
 import sys
 import os
 import time
-import glob
-import PIL.Image as Image
 import numpy as np
 
 import theano
@@ -45,106 +43,9 @@ import lasagne
 #import Cae
 import Cae_BigDenseLeaky
 
-
-#################
-
-def im2ar(x):
-    y = [[[0]*len(x)]*len(x)]*3
-    y[0] = x[:,:,0]
-    y[1] = x[:,:,1]
-    y[2] = x[:,:,2]
-    return y
-
-def ar2im(x):
-    y = [[[0]*3]*len(x)]*len(x)
-    y[:,:,0] = x[0,:,:] 
-    y[:,:,1] = x[1,:,:]
-    y[:,:,2] = x[2,:,:]
-    return y
+from common import im2ar, ar2im, np_ar2im, load_dataset_mscoco
+from common import save_jpg_results, create_html_results_page
     
-##################
-
-def load_dataset_mscoco():
-    #Path
-    
-    mscoco="/home2/ift6ed38/PythonCode/inpainting"
-    split="train2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    print("cantidad de imagenes = "+str(len(imgs)))
-    
-    MAXIMAS_train = 5000
-    MAXIMAS_val   = 1000
-    TESTSETsize   =  100
-    
-    X_train = []
-    y_train = []
-
-    
-    
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_train: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for training was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            temp = np.copy(img_array)
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_train.append(im2ar(input))
-        y_train.append(im2ar(target))
-    
-    split="val2014"
-    data_path = os.path.join(mscoco, split)
-    imgs = glob.glob(data_path + "/*.jpg")
-    
-    X_val = []
-    y_val = []
-            
-    for i, img_path in enumerate(imgs):
-        
-        if i == MAXIMAS_val: #If the number of images exceeds the limit
-            print("limit of "+str(i)+" images for validation was achieved")    
-            break
-        
-        img = Image.open(img_path)
-        img_array = np.divide(np.array(img,dtype='float32'),255)
-
-        if len(img_array.shape) == 3:
-            input = np.copy(img_array)
-            input[16:48, 16:48,:] = 0
-            target = img_array[16:48, 16:48,:]
-        else:
-            input[:,:,0] = np.copy(img_array)
-            input[:,:,1] = np.copy(img_array)
-            input[:,:,2] = np.copy(img_array)
-            target = input[16:48, 16:48,:]
-            input[16:48, 16:48,:] = 0
-        
-        X_val.append(im2ar(input))
-        y_val.append(im2ar(target))
-    
-    # We reserve the last TESTSETsize training examples for testing. (was 10000)
-    print("From the validation set, the last  "+str(TESTSETsize)+" images are chosen for testing") 
-    X_val, X_test = X_val[:-TESTSETsize], X_val[-TESTSETsize:]
-    y_val, y_test = y_val[:-TESTSETsize], y_val[-TESTSETsize:]
-    
-    return (np.array(X_train),np.array(y_train),np.array(X_val),np.array(y_val),np.array(X_test),np.array(y_test))
-    
-
 ###################
 
 # Batch iterator
@@ -190,10 +91,10 @@ def iterate_minibatches(inputs, targets, batchsize, shuffle=False):
 def main():
     
     # Hyper Params
-    num_epochs = 20 #was 100
+    num_epochs = 1 #was 100
     learning_rate = 0.001
     momentum = 0.975
-    batchsize = 10 #Was 200
+    batchsize = 100 #Was 200
     
     #Variance of the prediction can be maximized to obtain sharper images.
     #If this coefficient is set to "0", the loss is just the L2 loss.
@@ -201,7 +102,7 @@ def main():
     
     # Load the dataset
     print("Loading data...")
-    X_train, y_train, X_val, y_val, X_test, y_test = load_dataset_mscoco()
+    X_train, y_train, X_val, y_val, X_test, y_test, X_original_test = load_dataset_mscoco()
     #print("length of y_train = " + str(y_train))
     #print("length of y_val = "+ str(y_val))
     #print("length of y_test = "+str(y_test))
@@ -230,7 +131,8 @@ def main():
     # Update expressions 
     # Stochastic Gradient Descent (SGD) with Nesterov momentum
     params = lasagne.layers.get_all_params(network, trainable=True)
-    updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    #updates = lasagne.updates.nesterov_momentum(loss, params, learning_rate, momentum)
+    updates = lasagne.updates.adam(loss, params, learning_rate)
 
     # Test Loss expression
     # 'Deterministic = True' disables droupout
@@ -243,6 +145,10 @@ def main():
 
     # Test Function
     val_fn = theano.function([inputVar, target_var], test_loss)
+
+    # Predict function
+    predict = theano.function([inputVar], test_prediction)
+    
     # Training Loop
     print("Starting training...")
     # We iterate over epochs
@@ -270,24 +176,39 @@ def main():
         print("Epoch {} of {} took {:.3f}s".format(
             epoch + 1, num_epochs, time.time() - start_time))
         #print("  COMMENTARY: train_batches = "+str(train_batches))
-        print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
-        print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
+        if train_batches == 0:
+            print("train_batches is 0, can't compute training loss")
+        else:
+            print("  training loss:\t\t{:.6f}".format(train_err / train_batches))
+        if val_batches == 0:
+            print("val_batches is 0, can't compute validation loss")
+        else:
+            print("  validation loss:\t\t{:.6f}".format(val_err / val_batches))
 
     # Print the test error
     test_err = 0
     test_batches = 0
+    preds = np.zeros((X_test.shape[0], 3, 32, 32))
     for batch in iterate_minibatches(X_test, y_test, batchsize, shuffle=False):
         inputs, targets = batch
+        preds[test_batches*batchsize:(test_batches+1)*batchsize] = predict(inputs)
         err = val_fn(inputs, targets)
         test_err += err
         test_batches += 1
     print("Final results:")
-    print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
+    if test_batches == 0:
+        print("test_batches is 0, can't compute test loss.")
+    else:
+        print("  test loss:\t\t\t{:.6f}".format(test_err / test_batches))
 
 
     # Save model
     np.savez('caeOM-exp3.npz', *lasagne.layers.get_all_param_values(network))
-        
+
+    # Save predictions and create HTML page to visualize them
+    save_jpg_results("assets_exp3/", preds, X_test, y_test, X_original_test)
+    create_html_results_page("results_exp3.html", "assets_exp3/", preds.shape[0])
+    
 ###########################
 
 if __name__ == '__main__':

--- a/common.py
+++ b/common.py
@@ -1,0 +1,190 @@
+import sys
+import os
+import glob
+import PIL.Image as Image
+import numpy as np
+import errno
+import subprocess
+
+def im2ar(x):
+    y = [[[0]*len(x)]*len(x)]*3
+    y[0] = x[:,:,0]
+    y[1] = x[:,:,1]
+    y[2] = x[:,:,2]
+    return y
+
+def ar2im(x):
+    y = [[[0]*3]*len(x)]*len(x)
+    y[:,:,0] = x[0,:,:] 
+    y[:,:,1] = x[1,:,:]
+    y[:,:,2] = x[2,:,:]
+    return y
+
+def np_ar2im(x):
+    rows = x.shape[0]
+    width = x.shape[2]
+    height = x.shape[3]
+    return x.transpose(0, 2, 3, 1).reshape(x.shape[0], width, height, 3)
+
+def does_dir_exist(path):
+    try:
+        os.stat(path)
+    except OSError, e:
+        if e.errno == errno.ENOENT:
+            return False
+        else:
+            raise e
+    return True
+
+
+def load_dataset_mscoco():
+    #Path
+
+    tmp_dir = "/Tmp"
+    if not does_dir_exist(tmp_dir):
+        tmp_dir="/tmp"
+    mscoco = os.path.join(tmp_dir, "inpainting")
+    if not does_dir_exist(mscoco):
+        project_dataset_url="http://lisaweb.iro.umontreal.ca/transfert/lisa/datasets/mscoco_inpaiting/inpainting.tar.bz2"
+        print("Could not find mscoco dataset. Downloading dataset from: {}".format(project_dataset_url))
+        subprocess.call(["wget", "--continue", "-P", tmp_dir, project_dataset_url])
+        print("Extracting dataset into directory: {}".format(mscoco))
+        subprocess.call(["tar", "xf", os.path.join(tmp_dir, "inpainting.tar.bz2"), "-C", tmp_dir])
+
+    split="train2014"
+    data_path = os.path.join(mscoco, split)
+    imgs = glob.glob(data_path + "/*.jpg")
+    print("cantidad de imagenes = "+str(len(imgs)))
+    
+    MAXIMAS_train = 100000
+    MAXIMAS_val   = 1000
+    TESTSETsize   =  100
+    
+    X_train = []
+    y_train = []
+
+    
+    
+            
+    for i, img_path in enumerate(imgs):
+        
+        if i == MAXIMAS_train: #If the number of images exceeds the limit
+            print("limit of "+str(i)+" images for training was achieved")    
+            break
+        
+        img = Image.open(img_path)
+        img_array = np.divide(np.array(img,dtype='float32'),255)
+
+        if len(img_array.shape) == 3:
+            temp = np.copy(img_array)
+            input = np.copy(img_array)
+            input[16:48, 16:48,:] = 0
+            target = img_array[16:48, 16:48,:]
+        else:
+            input[:,:,0] = np.copy(img_array)
+            input[:,:,1] = np.copy(img_array)
+            input[:,:,2] = np.copy(img_array)
+            target = input[16:48, 16:48,:]
+            input[16:48, 16:48,:] = 0
+        
+        X_train.append(im2ar(input))
+        y_train.append(im2ar(target))
+    
+    split="val2014"
+    data_path = os.path.join(mscoco, split)
+    imgs = glob.glob(data_path + "/*.jpg")
+
+    X_original = []
+    X_val = []
+    y_val = []
+            
+    for i, img_path in enumerate(imgs):
+        
+        if i == MAXIMAS_val: #If the number of images exceeds the limit
+            print("limit of "+str(i)+" images for validation was achieved")    
+            break
+        
+        img = Image.open(img_path)
+        img_array = np.divide(np.array(img,dtype='float32'),255)
+
+        if len(img_array.shape) == 3:
+            input = np.copy(img_array)
+            original = np.copy(img_array)
+            input[16:48, 16:48,:] = 0
+            target = img_array[16:48, 16:48,:]
+        else:
+            input[:,:,0] = np.copy(img_array)
+            input[:,:,1] = np.copy(img_array)
+            input[:,:,2] = np.copy(img_array)
+            original[:,:,0] = np.copy(img_array)
+            original[:,:,1] = np.copy(img_array)
+            original[:,:,2] = np.copy(img_array)
+            target = input[16:48, 16:48,:]
+            input[16:48, 16:48,:] = 0
+
+        X_original.append(im2ar(original))
+        X_val.append(im2ar(input))
+        y_val.append(im2ar(target))
+    # We reserve the last TESTSETsize training examples for testing. (was 10000)
+    print("From the validation set, the last  "+str(TESTSETsize)+" images are chosen for testing")
+    X_original_val, X_original_test = X_original[:-TESTSETsize], X_original[-TESTSETsize:]
+    X_val, X_test = X_val[:-TESTSETsize], X_val[-TESTSETsize:]
+    y_val, y_test = y_val[:-TESTSETsize], y_val[-TESTSETsize:]
+    
+    return (np.array(X_train),np.array(y_train),np.array(X_val),np.array(y_val),np.array(X_test),np.array(y_test),np.array(X_original_test))
+    
+
+def save_jpg_results(assets_dir, preds, X_test, y_test, X_original_test):
+    if not os.path.exists(assets_dir):
+        os.makedirs(assets_dir)
+
+    # Denormalize images datasets
+    preds = (preds*255).clip(0, 255).astype('uint8')
+    X_test = (X_test*255).clip(0, 255).astype('uint8')
+    y_test = (y_test*255).clip(0, 255).astype('uint8')
+    X_original_test = (X_original_test*255).clip(0, 255).astype('uint8')
+
+    # Save the 100 predictions to JPG files within the 'assets' subdirectory
+    X_test = np_ar2im(X_test)
+    preds = np_ar2im(preds)
+    y_test = np_ar2im(y_test)
+    X_original_test = np_ar2im(X_original_test)
+    for index in range(preds.shape[0]):
+        Image.fromarray(X_test[index]).save(os.path.join(assets_dir, 'images_outer2d_' + str(index) + '.jpg'))
+        Image.fromarray(preds[index]).save(os.path.join(assets_dir, 'images_pred_' + str(index) + '.jpg'))
+        Image.fromarray(y_test[index]).save(os.path.join(assets_dir, 'images_inner2d_' + str(index) + '.jpg'))
+        Image.fromarray(X_original_test[index]).save(os.path.join(assets_dir, 'fullimages_' + str(index) + '.jpg'))
+        fullimg_pred = np.copy(X_original_test[index])
+        center = (int(np.floor(fullimg_pred.shape[0] / 2.)), int(np.floor(fullimg_pred.shape[1] / 2.)))
+        fullimg_pred[center[0]-16:center[0]+16, center[1]-16:center[1]+16, :] = preds[index, :, :, :]
+        Image.fromarray(fullimg_pred).save(os.path.join(assets_dir, 'fullimages_pred_' + str(index) + '.jpg'))
+
+def create_html_results_page(filename, assets_dir, num_images):
+        # Write a file called 'results.html' that display the image predictions versus the true images in a convenient way
+    img_src = assets_dir
+    if not img_src[-1] == '/':
+        img_src += '/'
+    html_file = filename
+    with open(html_file, 'w') as fd:
+        fd.write("""
+<table>
+  <tr>
+    <th style="width:132px">Input</th>
+    <th style="width:68px">Model prediction</th>
+    <th style="width:68px">Correct output</th> 
+    <th style="width:132px">Input + prediction</th>
+    <th style="width:132px">Input + correct output</th>
+  </tr>
+""")
+
+        for index in range(num_images):
+            fd.write("  <tr>\n")
+            fd.write("    <td><img src='%s/images_outer2d_%i.jpg' width='128' height='128'></td>\n" % (img_src, index))
+            fd.write("    <td><img src='%s/images_pred_%i.jpg' width='64' height='64'></td>\n" % (img_src, index))
+            fd.write("    <td><img src='%s/images_inner2d_%i.jpg' width='64' height='64'></td>\n" % (img_src, index))
+            fd.write("    <td><img src='%s/fullimages_pred_%i.jpg' width='128' height='128'></td>\n" % (img_src, index))
+            fd.write("    <td><img src='%s/fullimages_%i.jpg' width='128' height='128'></td>\n" % (img_src, index))
+            fd.write('</tr>\n')
+        
+        fd.write('</table>')
+        


### PR DESCRIPTION
- As I was curious to visualize the results of your models, I essentially copy/pasted the visualization code from my project onto yours, basically the code saves the results (the predictions from the test dataset, as well as the corresponding input and true output) as JPG images and creates HTML file to visualize results.
- I also made a few minor tweaks, like automatically download the project dataset and extracting the archive in /tmp/inpainting if this directory doesn't already exist.
- I also changed the optimizer from Nesterov momentum to adam.
- I put all my code in a new file called common.py
- Each model (#1, #2, #3) will now use the code from common.py to automatically save their results to disk and create an HTML file to view them (it will use different directory names and HTML file names for each experiment to avoid overwriting each other's results)
- I increased the default size of the training dataset to the entire dataset. If using CPU, you should lower it down to ~5000.